### PR TITLE
hacky! regex the title when whitespace gets escaped in slug;

### DIFF
--- a/src/app/(app)/components/Offers.tsx
+++ b/src/app/(app)/components/Offers.tsx
@@ -16,7 +16,7 @@ const items = [
   { icon: '/illus/geburt-auf-ball.svg', title: 'Geburt' },
   { icon: '/illus/paar-mit-baby.svg', title: 'Wochenbett' },
   { icon: '/illus/frau-auf-ball.svg', title: 'Kurse' },
-  { icon: '/illus/Fehlgeburt.svg', title: 'Begleitete Fehlgeburt' },
+  // { icon: '/illus/Fehlgeburt.svg', title: 'Begleitete Fehlgeburt' },
   {
     icon: '/illus/frauen-sprechen.svg',
     title: 'Info-Veranstaltungen',
@@ -60,7 +60,16 @@ function CarouselSize() {
               <div className="p-1">
                 <Card className="rounded-lg bg-white ">
                   <CardContent className="w-70 h-70 flex flex-col items-center justify-center p-6 text-center">
-                    <Link href={`/services/${title}`} className="flex flex-col items-center">
+                    <Link
+                      href={
+                        title === 'Kurse'
+                          ? '/courses'
+                          : title === 'Info-Veranstaltungen'
+                            ? '#schedule'
+                            : `/services/${title.replace(/\s+/g, ' ')}`
+                      }
+                      className="flex flex-col items-center"
+                    >
                       <Image
                         src={icon}
                         width={250}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="de">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased scroll-smooth`}>
         <Navbar className="hidden md:block" />
         <MobileNavbar className="md:hidden" />
         {children}

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -23,7 +23,9 @@ export default async function Home() {
 
       <Contact imageUrl="/woman-preg.jpeg" buttonVariant="default" />
 
-      <Schedule />
+      <div id="schedule" className="w-full">
+        <Schedule />
+      </div>
 
       <div className="relative flex w-full bg-primary-darker items-center justify-center self-stretch pb-0 pt-[125px]">
         <Image

--- a/src/app/(app)/services/[slug]/page.tsx
+++ b/src/app/(app)/services/[slug]/page.tsx
@@ -26,7 +26,7 @@ export default async function ServiceDetailPage({ params }: { params: Promise<{ 
   return (
     <main>
       <Header
-        title={service.title || ''}
+        title={service.title?.replace(/[\s\d\W]+/g, ' ') || ''}
         image={service.image ? urlFor(service.image).url() : '/default-image.jpg'}
         subtitle={service.description || ''}
       />


### PR DESCRIPTION
Introduce a temporary slug parsing hack to maintain existing routing behavior.

This PR adds a quick fix to parse titles into slugs without changing the current routing approach.

Note: I am considering adding a dedicated slug field to the collection schema and updating queries and frontend logic accordingly. What are your thoughts on this?
